### PR TITLE
Add `Volt.Formatter` — `mix format` plugin for JS/TS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 
 
+## Unreleased
+
+### Added
+
+- `Volt.Formatter` — `mix format` plugin for JS/TS. Add `plugins: [Volt.Formatter]` to `.formatter.exs` and JS/TS files are formatted alongside Elixir with oxfmt.
+- `mix igniter.install volt` now adds `Volt.Formatter` to `.formatter.exs` automatically.
+
 ## 0.8.1
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -350,6 +350,24 @@ API: `accept()`, `accept(deps, cb)`, `dispose(cb)`, `data`, `invalidate()`.
 Set up Volt in a Phoenix project. Adds config, dev server plug, watcher,
 removes esbuild/tailwind deps.
 
+### `mix format` integration
+
+`Volt.Formatter` is a `mix format` plugin — add it to `.formatter.exs` and JS/TS files are formatted alongside Elixir:
+
+```elixir
+# .formatter.exs
+[
+  plugins: [Volt.Formatter],
+  inputs: [
+    "{mix,.formatter}.exs",
+    "{config,lib,test}/**/*.{ex,exs}",
+    "assets/**/*.{js,ts,jsx,tsx}"
+  ]
+]
+```
+
+Reads options from `config :volt, :format` or `.oxfmtrc.json` (see below).
+
 ### `mix volt.js.format`
 
 Format JavaScript and TypeScript assets using oxfmt via NIF — no Node.js required.

--- a/lib/mix/tasks/volt.install.ex
+++ b/lib/mix/tasks/volt.install.ex
@@ -16,8 +16,9 @@ if Code.ensure_loaded?(Igniter) do
     1. Remove `:esbuild` and `:tailwind` deps
     2. Add Volt build config to `config/config.exs`
     3. Add format and lint config to `config/config.exs`
-    4. Add `Volt.DevServer` plug to your endpoint
-    5. Add the Volt watcher to `config/dev.exs`
+    4. Add `Volt.Formatter` plugin to `.formatter.exs`
+    5. Add `Volt.DevServer` plug to your endpoint
+    6. Add the Volt watcher to `config/dev.exs`
 
     You may need to manually remove old `config :esbuild` and
     `config :tailwind` blocks from `config/config.exs`.
@@ -43,6 +44,7 @@ if Code.ensure_loaded?(Igniter) do
       |> add_volt_config()
       |> add_format_config()
       |> add_lint_config()
+      |> add_formatter_plugin()
       |> add_dev_config(app_name)
       |> add_dev_server_plug()
     end
@@ -157,6 +159,10 @@ if Code.ensure_loaded?(Igniter) do
          ]
          """)}
       )
+    end
+
+    defp add_formatter_plugin(igniter) do
+      Igniter.Project.Formatter.add_formatter_plugin(igniter, Volt.Formatter)
     end
 
     defp add_dev_config(igniter, app_name) do

--- a/lib/volt/formatter.ex
+++ b/lib/volt/formatter.ex
@@ -1,0 +1,43 @@
+defmodule Volt.Formatter do
+  @moduledoc """
+  A `mix format` plugin that formats JavaScript and TypeScript files with oxfmt.
+
+  ## Setup
+
+  Add `Volt.Formatter` to your `.formatter.exs`:
+
+      [
+        plugins: [Volt.Formatter],
+        inputs: [
+          "{mix,.formatter}.exs",
+          "{config,lib,test}/**/*.{ex,exs}",
+          "assets/**/*.{js,ts,jsx,tsx}"
+        ]
+      ]
+
+  ## Configuration
+
+  Reads options from `config :volt, :format` or falls back to
+  `.oxfmtrc.json` / `.prettierrc.json`. See `Volt.JS.Format` for details.
+  """
+
+  @behaviour Mix.Tasks.Format
+
+  @extensions ~w(.js .ts .jsx .tsx .mjs .mts)
+
+  @impl true
+  def features(_opts) do
+    [extensions: @extensions]
+  end
+
+  @impl true
+  def format(contents, opts) do
+    filename = opts[:file] || extension_to_filename(opts[:extension]) || "input.ts"
+    format_opts = Volt.JS.Format.load_config()
+
+    OXC.Format.run!(contents, filename, format_opts)
+  end
+
+  defp extension_to_filename(nil), do: nil
+  defp extension_to_filename(ext), do: "input#{ext}"
+end

--- a/test/formatter_test.exs
+++ b/test/formatter_test.exs
@@ -1,0 +1,54 @@
+defmodule Volt.FormatterTest do
+  use ExUnit.Case, async: true
+
+  describe "features/1" do
+    test "returns JS/TS extensions" do
+      features = Volt.Formatter.features([])
+
+      assert ".js" in features[:extensions]
+      assert ".ts" in features[:extensions]
+      assert ".jsx" in features[:extensions]
+      assert ".tsx" in features[:extensions]
+      assert ".mjs" in features[:extensions]
+      assert ".mts" in features[:extensions]
+    end
+  end
+
+  describe "format/2" do
+    test "formats JavaScript" do
+      input = "const   x=1;  let  y =  2;"
+      result = Volt.Formatter.format(input, extension: ".js", file: "test.js")
+
+      assert result =~ "const x = 1"
+      assert result =~ "let y = 2"
+    end
+
+    test "formats TypeScript" do
+      input = "const   x:number=1;"
+      result = Volt.Formatter.format(input, extension: ".ts", file: "test.ts")
+
+      assert result =~ "const x: number = 1"
+    end
+
+    test "formats JSX" do
+      input = "const App = () =>   <div   className=\"foo\"  />"
+      result = Volt.Formatter.format(input, extension: ".jsx", file: "app.jsx")
+
+      assert result =~ "<div"
+    end
+
+    test "uses file option for filename" do
+      input = "const x   =   1;"
+      result = Volt.Formatter.format(input, extension: ".ts", file: "src/app.ts")
+
+      assert result =~ "const x = 1"
+    end
+
+    test "falls back to extension when file is missing" do
+      input = "const x   =   1;"
+      result = Volt.Formatter.format(input, extension: ".js")
+
+      assert result =~ "const x = 1"
+    end
+  end
+end


### PR DESCRIPTION
Adds a `Mix.Tasks.Format` plugin so `mix format` handles JS/TS files alongside Elixir — no separate `mix volt.js.format` step needed.

```elixir
# .formatter.exs
[
  plugins: [Volt.Formatter],
  inputs: [
    "{mix,.formatter}.exs",
    "{config,lib,test}/**/*.{ex,exs}",
    "assets/**/*.{js,ts,jsx,tsx}"
  ]
]
```

Uses the same oxfmt config path as the standalone task (`config :volt, :format` → `.oxfmtrc.json` → `.prettierrc.json`).

The igniter installer now adds the plugin to `.formatter.exs` automatically.