### PR TITLE
Fix entry chunks with dynamic imports

### DIFF
--- a/lib/volt/builder/output.ex
+++ b/lib/volt/builder/output.ex
@@ -136,11 +136,13 @@ defmodule Volt.Builder.Output do
         acc
       else
         chunk_js = Rewriter.rewrite_external_imports(chunk_js, ctx)
+        chunk_js = Rewriter.protect_dynamic_imports(chunk_js)
         bundle_opts = Keyword.put(bundle_opts, :entry, chunk_entry_label(chunk_js))
 
         case OXC.bundle(chunk_js, bundle_opts) do
           {:ok, result} ->
             {code, sourcemap} = BundleResult.extract(result)
+            code = Rewriter.restore_dynamic_imports(code)
             Map.put(acc, chunk_id, {code, sourcemap})
 
           {:error, _} ->

--- a/lib/volt/builder/rewriter.ex
+++ b/lib/volt/builder/rewriter.ex
@@ -3,12 +3,25 @@ defmodule Volt.Builder.Rewriter do
 
   alias Volt.Builder.Externals
 
+  @dynamic_import_keyword "import"
+  @dynamic_import_placeholder "$volt_"
+
   def rewrite_external_imports(js_files, ctx) do
     if MapSet.size(ctx.external_set) == 0 do
       js_files
     else
       Externals.rewrite_imports(js_files, ctx.external_set, ctx.external_globals)
     end
+  end
+
+  def protect_dynamic_imports(js_files) do
+    Enum.map(js_files, fn {label, code} ->
+      {label, protect_dynamic_imports_in_code(code)}
+    end)
+  end
+
+  def restore_dynamic_imports(code) do
+    String.replace(code, @dynamic_import_placeholder <> "(", @dynamic_import_keyword <> "(")
   end
 
   def inject_external_preamble(code, js_files, ctx) do
@@ -64,6 +77,38 @@ defmodule Volt.Builder.Rewriter do
       {:ok, rewritten} -> rewritten
       {:error, _} -> code
     end
+  end
+
+  defp protect_dynamic_imports_in_code(code) do
+    case OXC.parse(code, "chunk.js") do
+      {:ok, ast} ->
+        patches = collect_dynamic_import_protection_patches(ast)
+        if patches == [], do: code, else: OXC.patch_string(code, patches)
+
+      {:error, _} ->
+        code
+    end
+  end
+
+  defp collect_dynamic_import_protection_patches(ast) do
+    {_ast, patches} =
+      OXC.postwalk(ast, [], fn
+        %{type: :import_expression, start: start} = node, patches when is_integer(start) ->
+          {node, [dynamic_import_protection_patch(start) | patches]}
+
+        node, patches ->
+          {node, patches}
+      end)
+
+    patches
+  end
+
+  defp dynamic_import_protection_patch(start) do
+    %{
+      start: start,
+      end: start + byte_size(@dynamic_import_keyword),
+      change: @dynamic_import_placeholder
+    }
   end
 
   defp collect_dynamic_import_patches(ast, module_to_chunk, chunk_url_map) do

--- a/test/builder_test.exs
+++ b/test/builder_test.exs
@@ -383,6 +383,45 @@ defmodule Volt.BuilderTest do
       assert Enum.any?(chunk_files, &(&1 =~ "lib"))
     end
 
+    test "code splitting keeps entry bundle when entry has dynamic import" do
+      File.write!(Path.join(@fixture_dir, "src/lazy.ts"), """
+      export const lazyValue = 'lazy-loaded'
+      """)
+
+      File.write!(Path.join(@fixture_dir, "src/dynamic_entry.ts"), """
+      document.body.dataset.entry = 'dynamic-entry'
+
+      import('./lazy').then((mod) => {
+        document.body.dataset.lazy = mod.lazyValue
+      })
+      """)
+
+      {:ok, result} =
+        Volt.Builder.build(
+          entry: Path.join(@fixture_dir, "src/dynamic_entry.ts"),
+          outdir: @outdir,
+          name: "dynamic-entry",
+          format: :esm,
+          hash: false,
+          minify: false,
+          sourcemap: false
+        )
+
+      assert File.regular?(result.js.path)
+      assert Path.basename(result.js.path) == "dynamic-entry.js"
+
+      entry_js = File.read!(Path.join(@outdir, "dynamic-entry.js"))
+      assert entry_js =~ "dynamic-entry"
+      assert entry_js =~ ~r/import\(["']\.\/dynamic-entry-lazy\.js["']\)/
+      refute entry_js =~ "$volt_"
+
+      lazy_js = File.read!(Path.join(@outdir, "dynamic-entry-lazy.js"))
+      assert lazy_js =~ "lazy-loaded"
+
+      manifest = Path.join(@outdir, "manifest.json") |> File.read!() |> :json.decode()
+      assert manifest["dynamic-entry.js"]["file"] == "dynamic-entry.js"
+    end
+
     test "eager import.meta.glob dependencies resolve from original source directory" do
       File.mkdir_p!(Path.join(@fixture_dir, "src/components"))
 


### PR DESCRIPTION
## Summary

- Preserve entry chunks when a code-split entry contains `import(...)`.
- Add an AST-backed protection pass before per-chunk OXC bundling, then restore `import(...)` before Volt rewrites chunk URLs.
- Add a regression test covering an ESM entry that dynamically imports a lazy chunk.

## Why

When Volt builds code-split chunks, each chunk is bundled independently with OXC. If the entry chunk still contains a dynamic import during that per-chunk bundle, OXC can treat the entry as a wrapper for the dynamic chunk and emit the lazy module as the apparent entry bundle. The resulting manifest points `app.js` at the lazy chunk, so the real entry code never runs.

## Verification

- `mix test test/builder_test.exs:386`
- `mix test test/builder_test.exs`
- `mix test`
- `mix format --check-formatted`
- `mix credo --strict`
- `git diff --check`

I also tried `mix lint`, but it currently stops on existing JavaScript checks outside this patch:

- `priv/ts/tailwind-runtime.ts` needs formatting
- `priv/ts/error-overlay.ts` reports an unused `renderErrorOverlay`

## Related

Fixes #6.

## AI Disclosure

This PR was prepared with assistance from OpenAI Codex. I reproduced the bug locally, added the regression test first, and ran the verification commands listed above.
