### PR TITLE
Keep watcher cache separate from dev responses

### DIFF
--- a/lib/volt/cache.ex
+++ b/lib/volt/cache.ex
@@ -1,12 +1,14 @@
 defmodule Volt.Cache do
   @moduledoc """
-  ETS-backed module cache keyed by `{path, mtime}`.
+  ETS-backed module cache keyed by `{cache_key, mtime}`.
 
   Caches compiled output so repeated requests for unchanged files
   skip the compilation step entirely.
   """
 
   @table :volt_cache
+
+  @type key :: String.t() | {:watcher, String.t()}
 
   @type entry :: %{
           code: String.t(),
@@ -26,25 +28,25 @@ defmodule Volt.Cache do
   end
 
   @doc "Look up a cached entry. Returns `nil` on miss."
-  @spec get(String.t(), integer()) :: entry() | nil
-  def get(path, mtime) do
-    case :ets.lookup(@table, {path, mtime}) do
+  @spec get(key(), integer()) :: entry() | nil
+  def get(key, mtime) do
+    case :ets.lookup(@table, {key, mtime}) do
       [{_, entry}] -> entry
       [] -> nil
     end
   end
 
   @doc "Store a compiled entry."
-  @spec put(String.t(), integer(), entry()) :: :ok
-  def put(path, mtime, entry) do
-    :ets.insert(@table, {{path, mtime}, entry})
+  @spec put(key(), integer(), entry()) :: :ok
+  def put(key, mtime, entry) do
+    :ets.insert(@table, {{key, mtime}, entry})
     :ok
   end
 
-  @doc "Evict all entries for a path (any mtime)."
-  @spec evict(String.t()) :: :ok
-  def evict(path) do
-    :ets.match_delete(@table, {{path, :_}, :_})
+  @doc "Evict all entries for a cache key (any mtime)."
+  @spec evict(key()) :: :ok
+  def evict(key) do
+    :ets.match_delete(@table, {{key, :_}, :_})
     :ok
   end
 

--- a/lib/volt/watcher.ex
+++ b/lib/volt/watcher.ex
@@ -178,9 +178,11 @@ defmodule Volt.Watcher do
 
   defp handle_js_change(path, state) do
     relative = Path.relative_to(path, state.root)
+    watcher_cache_key = {:watcher, path}
 
     old_mtime = Volt.Format.file_mtime(path)
-    old_entry = Volt.Cache.get(path, old_mtime)
+    old_entry = Volt.Cache.get(watcher_cache_key, old_mtime)
+    Volt.Cache.evict(watcher_cache_key)
     Volt.Cache.evict(path)
 
     case File.read(path) do
@@ -197,7 +199,7 @@ defmodule Volt.Watcher do
               content_type: "application/javascript"
             }
 
-            Volt.Cache.put(path, mtime, entry)
+            Volt.Cache.put(watcher_cache_key, mtime, entry)
             update_dep_graph(path, result.code)
 
             changes = detect_changes(old_entry, result)

--- a/test/volt/dev_server_test.exs
+++ b/test/volt/dev_server_test.exs
@@ -118,6 +118,49 @@ defmodule Volt.DevServerTest do
       assert conn.status == 200
       assert conn.resp_body =~ "const x = 42"
     end
+
+    test "does not serve watcher analysis cache entries as browser responses" do
+      source_dir = Path.join(@fixture_dir, "src")
+      app_path = Path.join(source_dir, "app.ts")
+
+      File.write!(app_path, """
+      import "phoenix_html"
+      console.log(import.meta.env.DEV, "before")
+      """)
+
+      File.touch!(app_path, {{2026, 1, 1}, {0, 0, 0}})
+
+      conn = call_dev_server("/assets/app.ts")
+
+      assert conn.status == 200
+      assert conn.resp_body =~ "before"
+      assert conn.resp_body =~ "createHotContext"
+      assert conn.resp_body =~ "import.meta.env = "
+      assert conn.resp_body =~ "/@vendor/phoenix_html.js"
+      refute conn.resp_body =~ ~s(import "phoenix_html")
+
+      File.write!(app_path, """
+      import "phoenix_html"
+      console.log(import.meta.env.DEV, "after")
+      """)
+
+      File.touch!(app_path, {{2026, 1, 1}, {0, 0, 1}})
+
+      watcher =
+        start_supervised!({Volt.Watcher, root: source_dir, name: :test_dev_server_watcher_cache})
+
+      send(watcher, {:rebuild, app_path})
+      _ = :sys.get_state(watcher)
+
+      conn = call_dev_server("/assets/app.ts")
+
+      assert conn.status == 200
+      assert conn.resp_body =~ "after"
+      assert conn.resp_body =~ "createHotContext"
+      assert conn.resp_body =~ "import.meta.env = "
+      assert conn.resp_body =~ "/@vendor/phoenix_html.js"
+      refute conn.resp_body =~ ~s(import "phoenix_html")
+    end
   end
 
   describe "non-matching paths" do


### PR DESCRIPTION
## Summary

Fixes a dev-server cache collision where `Volt.Watcher` could store its watcher/analysis compile result under the same cache key used by `Volt.DevServer` browser responses.

After a source edit, the next request for the same JS module could receive raw compiled output instead of dev-server output, losing:

- HMR preamble injection
- `import.meta.env` injection
- dev import rewriting for bare imports

The watcher now stores its own cache entry under `{:watcher, path}` while still evicting the dev-server response key on source changes.

## Test

Adds a regression test that:

1. Requests a module through `Volt.DevServer`
2. Rebuilds the same file through `Volt.Watcher`
3. Requests the module again through `Volt.DevServer`
4. Asserts the response still has HMR, env injection, and vendor import rewriting

## Verification

- `mix format --check-formatted`
- `mix test test/volt/dev_server_test.exs`
- `mix test`
