### PR TITLE
Support plugin-provided vendor prebundle externals

### DIFF
--- a/lib/volt/js/vendor.ex
+++ b/lib/volt/js/vendor.ex
@@ -106,6 +106,10 @@ defmodule Volt.JS.Vendor do
     node_modules = Keyword.get(opts, :node_modules)
     module_dirs = module_dirs(node_modules, resolve_dirs)
 
+    browser_hash(module_dirs, plugins, module_types)
+  end
+
+  defp browser_hash(module_dirs, plugins, module_types) do
     :crypto.hash(
       :sha256,
       :erlang.term_to_binary(browser_signature(module_dirs, plugins, module_types))
@@ -202,11 +206,22 @@ defmodule Volt.JS.Vendor do
             preserve_entry_signatures: :strict
           ] ++ if(module_types != %{}, do: [module_types: module_types], else: [])
 
+        externals = prebundle_externals_for(specifier, plugins)
+        bundle_opts = put_external_imports(bundle_opts, externals)
+
         case OXC.bundle(entry_path, bundle_opts) do
           {:ok, result} ->
             write_cache_files!(
               output_path,
-              extract_code(result),
+              result
+              |> extract_code()
+              |> rewrite_external_imports(
+                entry_path,
+                externals,
+                plugins,
+                module_dirs,
+                module_types
+              ),
               specifier,
               module_dirs,
               plugins,
@@ -268,6 +283,46 @@ defmodule Volt.JS.Vendor do
   end
 
   # ── Helpers ───────────────────────────────────────────────────────
+
+  defp prebundle_externals_for(specifier, plugins) do
+    plugins
+    |> Volt.PluginRunner.prebundle_externals()
+    |> Enum.reject(fn external ->
+      Volt.PluginRunner.prebundle_alias(plugins, external) == specifier
+    end)
+  end
+
+  defp put_external_imports(bundle_opts, externals) do
+    Keyword.update(bundle_opts, :external, externals, fn existing ->
+      Enum.uniq(List.wrap(existing) ++ externals)
+    end)
+  end
+
+  defp rewrite_external_imports(code, entry_path, externals, plugins, module_dirs, module_types) do
+    rewrites =
+      Map.new(externals, fn external ->
+        canonical = Volt.PluginRunner.prebundle_alias(plugins, external)
+        {external, vendor_url_for_signature(canonical, module_dirs, plugins, module_types)}
+      end)
+
+    case Volt.JS.Transforms.Imports.rewrite_map(code, entry_path, rewrites) do
+      {:ok, rewritten} ->
+        rewritten
+
+      {:error, errors} ->
+        Logger.debug(
+          "[Volt] Vendor external import AST rewrite skipped for #{entry_path}: #{inspect(errors)}"
+        )
+
+        code
+    end
+  end
+
+  defp vendor_url_for_signature(specifier, module_dirs, plugins, module_types) do
+    specifier
+    |> vendor_url()
+    |> Volt.URL.append_query("v=#{browser_hash(module_dirs, plugins, module_types)}")
+  end
 
   defp extract_code(result) when is_binary(result), do: result
   defp extract_code(%{code: code}), do: code
@@ -443,7 +498,8 @@ defmodule Volt.JS.Vendor do
       lockfiles: lockfile_signature(module_dirs),
       module_dirs: module_dirs,
       module_types: module_types,
-      plugins: Enum.map(plugins, &base_plugin_signature/1)
+      plugins: Enum.map(plugins, &base_plugin_signature/1),
+      prebundle_externals: Volt.PluginRunner.prebundle_externals(plugins)
     }
   end
 

--- a/lib/volt/plugin.ex
+++ b/lib/volt/plugin.ex
@@ -91,6 +91,20 @@ defmodule Volt.Plugin do
                  imports: [prebundle_import()], exports: [prebundle_export()]}
               | nil
 
+  @doc """
+  Return bare specifiers that should stay external while dev vendor packages are pre-bundled.
+
+  Use this advanced framework-integration hook when third-party packages must
+  share a canonical dev vendor module instead of inlining their own copy of a
+  peer dependency. Volt rewrites preserved external imports through
+  `prebundle_alias/1`, so related entrypoints can still resolve to one vendor
+  URL.
+
+  The canonical prebundle entry itself is built without its aliased externals so
+  it can aggregate the shared dependency graph without importing itself.
+  """
+  @callback prebundle_externals() :: [String.t()]
+
   @doc "Transform a final output chunk before writing."
   @callback render_chunk(code :: String.t(), chunk_info :: map()) :: {:ok, String.t()} | nil
 
@@ -105,5 +119,6 @@ defmodule Volt.Plugin do
                       define: 1,
                       prebundle_alias: 1,
                       prebundle_entry: 1,
+                      prebundle_externals: 0,
                       render_chunk: 2
 end

--- a/lib/volt/plugin/react.ex
+++ b/lib/volt/plugin/react.ex
@@ -8,6 +8,7 @@ defmodule Volt.Plugin.React do
   alias Volt.JS.PrebundleEntry.{Export, Import}
 
   @react_exports ~w(
+    Activity
     Children
     Component
     Fragment
@@ -15,6 +16,12 @@ defmodule Volt.Plugin.React do
     PureComponent
     StrictMode
     Suspense
+    __CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE
+    __COMPILER_RUNTIME
+    act
+    cache
+    cacheSignal
+    captureOwnerStack
     cloneElement
     createContext
     createElement
@@ -31,6 +38,7 @@ defmodule Volt.Plugin.React do
     useDebugValue
     useDeferredValue
     useEffect
+    useEffectEvent
     useId
     useImperativeHandle
     useInsertionEffect
@@ -53,6 +61,16 @@ defmodule Volt.Plugin.React do
   def prebundle_alias("react/jsx-runtime"), do: "react"
   def prebundle_alias("react/jsx-dev-runtime"), do: "react"
   def prebundle_alias(_specifier), do: nil
+
+  @impl true
+  def prebundle_externals do
+    [
+      "react",
+      "react-dom/client",
+      "react/jsx-runtime",
+      "react/jsx-dev-runtime"
+    ]
+  end
 
   @impl true
   def prebundle_entry("react") do

--- a/lib/volt/plugin_runner.ex
+++ b/lib/volt/plugin_runner.ex
@@ -109,6 +109,20 @@ defmodule Volt.PluginRunner do
     end)
   end
 
+  @doc "Collect plugin-provided dev prebundle externals."
+  @spec prebundle_externals([module() | {module(), keyword()}]) :: [String.t()]
+  def prebundle_externals(plugins) do
+    plugins
+    |> plugins()
+    |> Enum.flat_map(fn plugin ->
+      plugin
+      |> call_optional(:prebundle_externals, [], [])
+      |> List.wrap()
+    end)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq()
+  end
+
   @doc "Run render_chunk hooks in sequence."
   @spec render_chunk([module() | {module(), keyword()}], String.t(), map()) :: String.t()
   def render_chunk(plugins, code, chunk_info) do

--- a/test/volt/js/vendor_test.exs
+++ b/test/volt/js/vendor_test.exs
@@ -145,6 +145,90 @@ defmodule Volt.JS.VendorTest do
       assert code =~ "greet"
       refute code =~ "module.exports"
     end
+
+    test "keeps third-party React imports external and rewrites them to canonical vendor URL" do
+      File.mkdir_p!(Path.join(@node_modules, "react"))
+      File.mkdir_p!(Path.join(@node_modules, "react-dom"))
+      File.mkdir_p!(Path.join(@node_modules, "react-using-lib"))
+
+      File.write!(
+        Path.join(@node_modules, "react/package.json"),
+        :json.encode(%{
+          "name" => "react",
+          "main" => "index.js",
+          "exports" => %{
+            "." => "./index.js",
+            "./jsx-runtime" => "./jsx-runtime.js",
+            "./jsx-dev-runtime" => "./jsx-dev-runtime.js"
+          },
+          "type" => "module"
+        })
+      )
+
+      File.write!(
+        Path.join(@node_modules, "react/index.js"),
+        "const React = { act() {}, useState(value) { return [value, () => {}]; } }; export default React; export const act = React.act; export const useState = React.useState;"
+      )
+
+      File.write!(
+        Path.join(@node_modules, "react/jsx-runtime.js"),
+        "export function jsx() {}; export function jsxs() {};"
+      )
+
+      File.write!(
+        Path.join(@node_modules, "react/jsx-dev-runtime.js"),
+        "export function jsxDEV() {};"
+      )
+
+      File.write!(
+        Path.join(@node_modules, "react-dom/package.json"),
+        :json.encode(%{
+          "name" => "react-dom",
+          "exports" => %{"./client" => "./client.js"},
+          "type" => "module"
+        })
+      )
+
+      File.write!(
+        Path.join(@node_modules, "react-dom/client.js"),
+        "export function createRoot() {}; export function hydrateRoot() {}; export const version = '0.0.0';"
+      )
+
+      File.write!(
+        Path.join(@node_modules, "react-using-lib/package.json"),
+        :json.encode(%{"name" => "react-using-lib", "main" => "index.js", "type" => "module"})
+      )
+
+      File.write!(
+        Path.join(@node_modules, "react-using-lib/index.js"),
+        "import { act, useState } from 'react'; export function useThing() { act(() => {}); return useState(null); }"
+      )
+
+      File.write!(
+        Path.join(@fixture_dir, "src/app.ts"),
+        "import { useThing } from 'react-using-lib'; console.log(useThing)"
+      )
+
+      {:ok, vendor_map} =
+        Volt.JS.Vendor.prebundle(
+          root: Path.join(@fixture_dir, "src"),
+          node_modules: @node_modules,
+          plugins: [Volt.Plugin.React]
+        )
+
+      assert Map.has_key?(vendor_map, "react-using-lib")
+
+      {:ok, code} = Volt.JS.Vendor.read("react-using-lib")
+
+      assert code =~ ~r/from "\/@vendor\/react\.js\?v=[a-f0-9]+"/
+      refute code =~ ~s(from "react")
+      refute code =~ ~s(from 'react')
+
+      {:ok, react_proxy} =
+        Volt.JS.Vendor.bundle_on_demand("react", @node_modules, plugins: [Volt.Plugin.React])
+
+      assert react_proxy =~ ~r/export \{[^}]*act/s
+    end
   end
 
   describe "CJS package bundling" do


### PR DESCRIPTION
## Summary

Adds a Volt plugin hook for dev vendor prebundling externals.

This lets framework/integration plugins declare bare imports that should remain external while third-party vendor packages are prebundled, then rewrites those preserved imports back to Volt vendor URLs.

## Use case

In a Phoenix + Volt React app, we use:

- React
- TanStack Router / Query / DB
- Base UI via shadcn
- lucide-react

Volt currently prebundles each vendor package independently in dev. Packages like `@base-ui/react`, `@tanstack/react-query`, and `lucide-react` may inline their own React copy during vendor prebundling. That produced duplicate React singletons and runtime errors such as:

- `Invalid hook call. Hooks can only be called inside of the body of a function component.`
- `Cannot read properties of null (reading 'useRef')`
- `Cannot read properties of null (reading 'useEffect')`
- `Cannot read properties of null (reading 'useContext')`

The app already had a plugin that canonicalized React-family imports to one `/@vendor/react.js` module, but vendor prebundling had no way to keep React external inside other prebundled vendor packages.

## What changed

- Adds optional `Volt.Plugin.prebundle_externals/0`
- Adds `Volt.PluginRunner.prebundle_externals/1`
- Passes plugin-provided externals to `OXC.bundle/2` during dev vendor prebundling
- Rewrites preserved external imports to canonical Volt vendor URLs using `prebundle_alias/1`
- Avoids self-externalizing the canonical prebundle entry itself
- Includes prebundle externals in the vendor browser/cache signature

## Tried before this

Before adding this hook, we tried app-side workarounds:

- Aliasing React-related packages through app config
- Canonicalizing React-family imports with `prebundle_alias/1`
- Creating a synthetic React vendor entry via `prebundle_entry/1`

Those helped top-level app imports, but did not prevent third-party vendor bundles from inlining React internally. Replacing Base UI/shadcn primitives with native React elements would have avoided the symptom, but was not acceptable because the goal is to support real Base UI/shadcn usage.

## Verification

Verified in the downstream app:

- `@base-ui/react`, TanStack, Floating UI, and `lucide-react` vendor bundles now import React from the singleton `/@vendor/react.js?...`
- Page renders with Base UI/shadcn components
- No React invalid-hook-call runtime errors
- Browser console has 0 errors / 0 warnings

Verified in this repo:

- `mix compile --warnings-as-errors`
- `MIX_ENV=test mix test`

## AI usage disclosure

This patch was developed with AI assistance. The AI helped investigate the duplicate React runtime issue, compare attempted solutions, draft the implementation, and run validation steps. The code and behavior were manually reviewed and verified with the test commands above. But I'm not very familiar with how Volt works, so I cannot take full responsibility for it. 