### PR TITLE
Rewrite CJS require() specifiers in production bundles

### DIFF
--- a/lib/volt/builder.ex
+++ b/lib/volt/builder.ex
@@ -404,10 +404,21 @@ defmodule Volt.Builder do
   defp rewrite_imports_to_labels(code, label_map, from_label, global_map) do
     code = rewrite_dynamic_css_imports(code)
 
-    case OXC.rewrite_specifiers(code, "module.js", fn specifier ->
-           rewrite_specifier(specifier, label_map, from_label, global_map)
-         end) do
-      {:ok, rewritten} -> rewritten
+    # `Volt.JS.Transforms.Specifiers.rewrite/4` rewrites ESM import/export AND CJS
+    # `require()` specifiers; the native `OXC.rewrite_specifiers/3` only handles the
+    # ESM forms, leaving `require()` calls untouched. CJS packages reach this step
+    # with internal `require()` calls (e.g. react-dom's `require("scheduler")`), so
+    # using the require-aware rewriter keeps those pointed at the bundled modules
+    # instead of leaking runtime `require()` calls into the browser output.
+    rewrite_fun = fn specifier, _importer, _ctx ->
+      case rewrite_specifier(specifier, label_map, from_label, global_map) do
+        {:rewrite, replacement} -> {:ok, replacement, specifier}
+        :keep -> :skip
+      end
+    end
+
+    case Volt.JS.Transforms.Specifiers.rewrite(code, "module.js", nil, rewrite_fun) do
+      {:ok, rewritten, _paths} -> rewritten
       {:error, _} -> code
     end
   end

--- a/test/volt/builder_test.exs
+++ b/test/volt/builder_test.exs
@@ -1361,6 +1361,53 @@ defmodule Volt.BuilderTest do
       assert js =~ "cjs-works"
     end
 
+    test "rewrites bare CJS require() to the bundled module (no runtime require leak)" do
+      File.mkdir_p!(Path.join(@fixture_dir, "node_modules/bare-cjs-dep"))
+      File.mkdir_p!(Path.join(@fixture_dir, "node_modules/cjs-consumer"))
+
+      File.write!(
+        Path.join(@fixture_dir, "node_modules/bare-cjs-dep/package.json"),
+        ~s({"name":"bare-cjs-dep","main":"index.js"})
+      )
+
+      File.write!(
+        Path.join(@fixture_dir, "node_modules/bare-cjs-dep/index.js"),
+        "module.exports = { token: 'bundled-bare-cjs' }\n"
+      )
+
+      File.write!(
+        Path.join(@fixture_dir, "node_modules/cjs-consumer/package.json"),
+        ~s({"name":"cjs-consumer","main":"index.js"})
+      )
+
+      # A CJS module that requires another package by bare name — mirrors
+      # react-dom's internal `require("scheduler")`.
+      File.write!(Path.join(@fixture_dir, "node_modules/cjs-consumer/index.js"), """
+      var dep = require('bare-cjs-dep')
+      module.exports = dep.token
+      """)
+
+      File.write!(Path.join(@fixture_dir, "src/bare_cjs_app.ts"), """
+      import token from 'cjs-consumer'
+      console.log(token)
+      """)
+
+      {:ok, result} =
+        Volt.Builder.build(
+          entry: Path.join(@fixture_dir, "src/bare_cjs_app.ts"),
+          outdir: @outdir,
+          minify: false,
+          sourcemap: false,
+          node_modules: Path.join(@fixture_dir, "node_modules")
+        )
+
+      js = File.read!(result.js.path)
+      # The dependency is bundled in, and the bare `require()` is rewritten to the
+      # bundled module rather than left as a runtime call that throws in browsers.
+      assert js =~ "bundled-bare-cjs"
+      refute js =~ ~r/require\(\s*[`"']bare-cjs-dep[`"']\s*\)/
+    end
+
     test "resolves package subpath without exports field" do
       File.mkdir_p!(Path.join(@fixture_dir, "node_modules/subpath-pkg/lib"))
 


### PR DESCRIPTION
Great project! Ran into 1-2 rough edges but I hope this helps

## Summary

Production builds (`mix volt.build`) leak CJS `require()` calls into the output bundle, which throw in the browser (`require is not defined` / `Calling "require" for "…"`).

`Volt.Builder.rewrite_imports_to_labels/4` rewrites every collected module's import specifiers to their bundled labels using the native `OXC.rewrite_specifiers/3`. That function only rewrites **ESM `import`/`export`** specifiers — it leaves **CJS `require()`** calls untouched.

CJS packages reach this step with internal bare `require()` calls. The canonical case is React: `react-dom/client` → `react-dom` (CJS) → `var Scheduler = require("scheduler"), React = require("react")`. Because those specifiers are never repointed at the bundled module labels, Rolldown can't link them, wraps the module in a CommonJS helper, and emits runtime `require(...)` calls. The required module is then unreferenced and tree-shaken out. In the browser this throws as soon as the bundle executes.

This affects any production build that includes a CJS package which `require()`s another bare package — most notably **every Volt + React app** doing a standard `createRoot` setup (Volt ships a React plugin, so this is the supported path).

## Fix

Use `Volt.JS.Transforms.Specifiers.rewrite/4` — Volt's own AST-based specifier rewriter, already used by the dev runtime bundler (`Volt.JS.Runtime.Bundler`) — which rewrites ESM `import`/`export`, dynamic `import()`, **and** `require()` specifiers. This makes the production label-rewrite step consistent with the collector, which already extracts `require()` imports (`Volt.JS.ImportExtractor.maybe_extract_require`) and walks into them.

One-function change; the require-aware rewriter is a superset of what `OXC.rewrite_specifiers/3` handled.

## Test

Adds a regression test that builds a CJS package which `require()`s another package by **bare** name (mirroring `react-dom` → `scheduler`). It asserts the dependency is bundled and that no runtime `require("…")` call leaks into the output.

- Before this change the test fails: the output contains `module.exports = require("bare-cjs-dep")` and the dependency is missing (tree-shaken).
- After: dependency bundled, no `require()` leak.

(The existing `collects CJS require() as imports` test only covers a *relative* `require('./helper')`, which Rolldown resolves by path among the virtual files even with the bug — so it didn't catch this.)

Verified downstream on a Phoenix + Volt + React 19 app: the production bundle previously threw `Calling "require" for "scheduler" in the browser`; with this change there are zero `require()` calls and the app renders. Full suite green (`mix test` — 395 passed).
