### PR TITLE
Skip node_modules when scanning source for vendor prebundling

### DIFF
--- a/lib/volt/js/vendor.ex
+++ b/lib/volt/js/vendor.ex
@@ -135,11 +135,15 @@ defmodule Volt.JS.Vendor do
 
   # ── Scanning ──────────────────────────────────────────────────────
 
+  # Directories never worth scanning for app imports. node_modules is the
+  # critical one: it can hold thousands of files (e.g. React + react-dom), and
+  # this scan re-runs frequently in dev — globbing into it made every asset
+  # request take seconds. A vendor's own imports are handled when it is bundled.
+  @scan_skip_dirs ~w(node_modules _build deps .git)
+
   defp scan_bare_imports(root, plugins) do
-    source_files =
-      Volt.JS.Extensions.scannable(plugins)
-      |> Enum.flat_map(fn ext -> Path.wildcard(Path.join(root, "**/*" <> ext)) end)
-      |> Enum.uniq()
+    exts = Volt.JS.Extensions.scannable(plugins)
+    source_files = collect_source_files(root, exts)
 
     specifiers =
       Enum.flat_map(source_files, fn file ->
@@ -152,6 +156,29 @@ defmodule Volt.JS.Vendor do
       end)
 
     {:ok, specifiers}
+  end
+
+  defp collect_source_files(dir, exts) do
+    case File.ls(dir) do
+      {:ok, entries} ->
+        Enum.flat_map(entries, fn entry ->
+          path = Path.join(dir, entry)
+
+          cond do
+            File.dir?(path) ->
+              if entry in @scan_skip_dirs, do: [], else: collect_source_files(path, exts)
+
+            Path.extname(entry) in exts ->
+              [path]
+
+            true ->
+              []
+          end
+        end)
+
+      {:error, _} ->
+        []
+    end
   end
 
   defp extract_imports(source, path, plugins) do

--- a/test/volt/js/vendor_test.exs
+++ b/test/volt/js/vendor_test.exs
@@ -50,6 +50,33 @@ defmodule Volt.JS.VendorTest do
       assert File.regular?("_build/volt/vendor/fake-lib.js")
     end
 
+    test "does not scan into node_modules under the root" do
+      # A real package referenced only from *inside* node_modules.
+      File.mkdir_p!(Path.join(@node_modules, "nested-only"))
+
+      File.write!(
+        Path.join(@node_modules, "nested-only/package.json"),
+        :json.encode(%{"name" => "nested-only", "main" => "index.js"})
+      )
+
+      File.write!(Path.join(@node_modules, "nested-only/index.js"), "export const x = 1;")
+
+      File.write!(
+        Path.join(@node_modules, "fake-lib/extra.js"),
+        "import { x } from 'nested-only'\nexport { x }\n"
+      )
+
+      # Scan the whole fixture, which contains both src/ and node_modules/.
+      {:ok, vendor_map} =
+        Volt.JS.Vendor.prebundle(root: @fixture_dir, node_modules: @node_modules)
+
+      # The app's own bare import is still detected...
+      assert Map.has_key?(vendor_map, "fake-lib")
+      # ...but an import that only appears *inside* node_modules is not, since the
+      # scan must not crawl dependency trees (thousands of files in real apps).
+      refute Map.has_key?(vendor_map, "nested-only")
+    end
+
     test "optimizes multiple packages in one shared dependency graph" do
       File.mkdir_p!(Path.join(@node_modules, "editor-a"))
       File.mkdir_p!(Path.join(@node_modules, "editor-b"))


### PR DESCRIPTION
Found another one.

## Summary

In dev, every asset request was taking ~2.5s on a Phoenix + Volt + React app. The cause is `Volt.JS.Vendor.scan_bare_imports/2`, which finds the app's bare imports by globbing `root/**/*.{js,ts,jsx,tsx,...}`. That glob descends into `node_modules`.

A React app's `node_modules` holds thousands of files (react, react-dom, etc.). The dev server re-runs this scan frequently (it ran on every asset request in our setup), so each request spent seconds globbing + reading + parsing dependency files. Measured on a small app: the scan globbed **2099 files in ~1.4s** (2099 of them in `node_modules`), and `/@vendor/*` and compiled source modules each took **~2.5s** to serve.

## Fix

Walk the source tree instead of globbing, skipping `node_modules`, `_build`, `deps`, and `.git`. A vendor's own imports are resolved when that vendor is bundled, so the top-level scan never needs to read them.

On the same app this drops the scan from 2099 files (~1.4s) to just the app's sources (~10 files, ~0.4ms), and dev asset requests from ~2.5s to ~5–120ms (~100x faster). No behavior change: the app's bare imports are still detected.

## Test

Adds a test asserting the scan finds an app's bare import but **not** one that only appears inside a `node_modules` package (when `node_modules` lives under the scan root). Fails before this change (the nested import gets prebundled), passes after.
